### PR TITLE
Remove Manuals download from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN    mkdir -p /home/gap/inst \
     && unzip gap-${GAP_VERSION}-core.zip \
     && rm gap-${GAP_VERSION}-core.zip \
     && cd gap-${GAP_VERSION} \
-    && wget https://www.gap-system.org/Manuals/gap-${GAP_VERSION}-manuals.tar.gz \
-    && tar xvzf gap-${GAP_VERSION}-manuals.tar.gz \
-    && rm gap-${GAP_VERSION}-manuals.tar.gz \
     && ./configure --with-gmp=system \
     && make \
     && cp bin/gap.sh bin/gap \


### PR DESCRIPTION
Currently, there is no tar ball associated with the following link for GAP 4.10.2:
https://www.gap-system.org/Manuals/gap-4.10.2-manuals.tar.gz
and as such the whole image deployment fails. This commit removes those instructions to allow for deployment of the Docker image.

While this allows the dockerfile to be migrated successfully to GHCR.io, it should be something to be aware of for later versions of GAP (i.e. is only a temporary fix).